### PR TITLE
Resolves #30 - Add SQL Server metrics to be correlated

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ For detailed information on this package, please refer to the [online documentat
 
 ### Version next
 
-* Adjusted build to use metricly-cli for validation
+* Adjusted build to use metricly-cli for validation.
+* Added SQL Server metrics to be correlated.
 
 ### Version 2.0.2
 

--- a/analyticConfigurations/ace-windows.winsrv.json
+++ b/analyticConfigurations/ace-windows.winsrv.json
@@ -42,6 +42,12 @@
         "correlation" : true
       }
     }, {
+      "match" : "sql_server\\..*",
+      "properties" : {
+        "baseline" : true,
+        "correlation" : true
+      }
+    }, {
       "match" : "system.context_switches_per_sec",
       "properties" : {
         "baseline" : true,


### PR DESCRIPTION
Adding all the SQL Server metrics to the model for correlation, per the research team recommendation.